### PR TITLE
add .gitignore to ignore zcompile outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+auto-fu
+*.zwc


### PR DESCRIPTION
- Add .gitignore to ignore zcompile outputs, like auto-fu and auto-fu.zwc.
- re-commit for signed-off
