### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ zstyle ':auto-fu:highlight' completion/one fg=white,bold,underline
 zstyle ':auto-fu:var' postdisplay $'
 -azfu-'
 zstyle ':auto-fu:var' track-keymap-skip opp
-#zstyle ':auto-fu:var' disable magic-space
+# zstyle ':auto-fu:var' disable magic-space
 
 XXX: use with the error correction or _match completer.
 If you got the correction errors during auto completing the word, then


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
